### PR TITLE
[27] Fix project Configuration in IntelliJ

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,8 +71,8 @@ config {
     bintray {
         enabled = true
         credentials {
-            username = System.getenv("BINTRAY_USER")
-            password = System.getenv("BINTRAY_KEY")
+            username = System.getenv("BINTRAY_USER") ?: "**UNDEFINED**"
+            password = System.getenv("BINTRAY_KEY") ?: "**UNDEFINED**"
         }
         userOrg = "difty"
         githubRepo = "ursjoss/KRis"


### PR DESCRIPTION
Resolves #27

Looks like for some reason in IntelliJ my environment variables `BINTRAY_USER` and `BINTRAY_KEY` were not parsed successfully, leaving `config.bintray.credentials.username` and `....password` null.

As I don't need the configuration from IntelliJ I simply worked around that by providing a fallback value.