### PR TITLE
chore: Switch on new JVM IR backend

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -169,6 +169,7 @@ configure<ProjectsExtension> {
                         apiVersion = kotlinVersion
                         languageVersion = kotlinVersion
                         jvmTarget = javaVersion.majorVersion
+                        useIR = true
                     }
                 }
             }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 @file:Suppress("SpellCheckingInspection")
 
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.kordamp.gradle.plugin.base.ProjectsExtension
 
 plugins {
@@ -164,7 +165,7 @@ configure<ProjectsExtension> {
                 named("clean").configure {
                     dependsOn(deleteOutFolderTask)
                 }
-                withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+                withType<KotlinCompile>().configureEach {
                     kotlinOptions {
                         apiVersion = kotlinVersion
                         languageVersion = kotlinVersion

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -219,7 +219,7 @@ configure<ProjectsExtension> {
                     }
                 }
 
-                val check by existing {
+                named("check") {
                     dependsOn("allTests")
                 }
             }


### PR DESCRIPTION
https://blog.jetbrains.com/kotlin/2021/02/the-jvm-backend-is-in-beta-let-s-make-it-stable-together/