### PR TITLE
chore(deps): Bump versions of dependencies

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -50,7 +50,7 @@ The format is based on https://keepachangelog.com/en/1.0.0/[Keep a Changelog].
 
 
 .Changed
-- Bumped gradle-wrapper, kotlin, coroutines, mockk, rxjava, junit, kordamp-gradle-plugins, kluent
+- Bumped gradle-wrapper, kotlin, coroutines, mockk, rxjava, junit, kordamp-gradle-plugins, kluent, assertj
 
 ////
 .Deprecated

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -50,7 +50,7 @@ The format is based on https://keepachangelog.com/en/1.0.0/[Keep a Changelog].
 
 
 .Changed
-- Bumped gradle-wrapper, kotlin, coroutines, mockk, rxjava, junit, kordamp-gradle-plugins
+- Bumped gradle-wrapper, kotlin, coroutines, mockk, rxjava, junit, kordamp-gradle-plugins, kluent
 
 ////
 .Deprecated

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -151,13 +151,6 @@ configure<ProjectsExtension> {
                 explicitApi()
             }
 
-            // workaround until resolution of https://github.com/kordamp/kordamp-gradle-plugins/issues/331
-            config {
-                licensing {
-                    enabled = false
-                }
-            }
-
             tasks {
                 val deleteOutFolderTask by registering(Delete::class) {
                     delete("out")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     id("org.ajoberstar.reckon")
 }
 
-val kotlinVersion = "1.4"
+val kotlinVersion: String by project
 val javaVersion = JavaVersion.VERSION_11
 val kotlinSrcSet = "/src/main/kotlin"
 val srcLinkSuffix = "#L"
@@ -165,13 +165,18 @@ configure<ProjectsExtension> {
                 named("clean").configure {
                     dependsOn(deleteOutFolderTask)
                 }
+                val kotlinApiLangVersion =  kotlinVersion.subSequence(0, 3).toString()
+                val jvmTargetVersion = javaVersion.toString()
                 withType<KotlinCompile>().configureEach {
                     kotlinOptions {
-                        apiVersion = kotlinVersion
-                        languageVersion = kotlinVersion
-                        jvmTarget = javaVersion.majorVersion
-                        useIR = true
+                        apiVersion = kotlinApiLangVersion
+                        languageVersion = kotlinApiLangVersion
+                        jvmTarget = jvmTargetVersion
                     }
+                }
+                withType<JavaCompile>().configureEach {
+                    sourceCompatibility = jvmTargetVersion
+                    targetCompatibility = jvmTargetVersion
                 }
             }
         }
@@ -191,7 +196,6 @@ configure<ProjectsExtension> {
             val assertjVersion: String by project
             val coroutinesVersion: String by project
             val kluentVersion: String by project
-            val kotlinVersion: String by project
             val junitJupiterVersion: String by project
             val spekVersion: String by project
             val mockkVersion: String by project

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 @file:Suppress("SpellCheckingInspection")
 
+import io.gitlab.arturbosch.detekt.Detekt
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.kordamp.gradle.plugin.base.ProjectsExtension
 
@@ -170,6 +171,9 @@ configure<ProjectsExtension> {
                 withType<JavaCompile>().configureEach {
                     sourceCompatibility = jvmTargetVersion
                     targetCompatibility = jvmTargetVersion
+                }
+                withType<Detekt>().configureEach {
+                    jvmTarget = jvmTargetVersion
                 }
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -143,8 +143,8 @@ configure<ProjectsExtension> {
 
             repositories {
                 mavenLocal()
-                jcenter()
                 mavenCentral()
+                jcenter()
             }
 
             kotlin {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -159,13 +159,14 @@ configure<ProjectsExtension> {
                 named("clean").configure {
                     dependsOn(deleteOutFolderTask)
                 }
-                val kotlinApiLangVersion =  kotlinVersion.subSequence(0, 3).toString()
+                val kotlinApiLangVersion = kotlinVersion.subSequence(0, 3).toString()
                 val jvmTargetVersion = javaVersion.toString()
                 withType<KotlinCompile>().configureEach {
                     kotlinOptions {
                         apiVersion = kotlinApiLangVersion
                         languageVersion = kotlinApiLangVersion
                         jvmTarget = jvmTargetVersion
+                        freeCompilerArgs = freeCompilerArgs + listOf("-Xopt-in=kotlin.RequiresOptIn")
                     }
                 }
                 withType<JavaCompile>().configureEach {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 group=ch.difty.kris
 
 # org.assertj:assertj-core
-assertjVersion=3.20.2
+assertjVersion=3.21.0
 # org.jetbrains.kotlinx:kotlinx-coroutines-core
 coroutinesVersion=1.5.1
 # org.ajoberstar.git-publish

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ gitPublishVersion=2.1.3
 junitJupiterVersion=5.7.2
 # org.amshove.kluent
 kluentVersion=1.67
-kotlinVersion=1.5.20
+kotlinVersion=1.5.21
 kordampPluginVersion=0.46.0
 # io.mockk:mockk
 mockkVersion=1.12.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,14 +3,14 @@ group=ch.difty.kris
 # org.assertj:assertj-core
 assertjVersion=3.19.0
 # org.jetbrains.kotlinx:kotlinx-coroutines-core
-coroutinesVersion=1.4.3
+coroutinesVersion=1.5.0
 # org.ajoberstar.git-publish
 gitPublishVersion=2.1.3
 # org.junit.jupiter:junit-jupiter-api
 junitJupiterVersion=5.7.2
 # org.amshove.kluent
 kluentVersion=1.65
-kotlinVersion=1.4.32
+kotlinVersion=1.5.10
 kordampPluginVersion=0.46.0
 # io.mockk:mockk
 mockkVersion=1.11.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ kluentVersion=1.68
 kotlinVersion=1.5.21
 kordampPluginVersion=0.46.0
 # io.mockk:mockk
-mockkVersion=1.12.0
+mockkVersion=1.12.1
 # org.ajoberstar.reckon
 reckonVersion=0.12.0
 # io.reactivex.rxjava2:rxjava

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ gitPublishVersion=2.1.3
 junitJupiterVersion=5.7.2
 # org.amshove.kluent
 kluentVersion=1.67
-kotlinVersion=1.5.10
+kotlinVersion=1.5.20
 kordampPluginVersion=0.46.0
 # io.mockk:mockk
 mockkVersion=1.11.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ kluentVersion=1.67
 kotlinVersion=1.5.20
 kordampPluginVersion=0.46.0
 # io.mockk:mockk
-mockkVersion=1.11.0
+mockkVersion=1.12.0
 # org.ajoberstar.reckon
 reckonVersion=0.12.0
 # io.reactivex.rxjava2:rxjava

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ gitPublishVersion=2.1.3
 junitJupiterVersion=5.8.2
 # org.amshove.kluent
 kluentVersion=1.68
-kotlinVersion=1.5.21
+kotlinVersion=1.6.10
 kordampPluginVersion=0.46.0
 # io.mockk:mockk
 mockkVersion=1.12.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ gitPublishVersion=2.1.3
 # org.junit.jupiter:junit-jupiter-api
 junitJupiterVersion=5.7.2
 # org.amshove.kluent
-kluentVersion=1.65
+kluentVersion=1.67
 kotlinVersion=1.5.10
 kordampPluginVersion=0.46.0
 # io.mockk:mockk

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ coroutinesVersion=1.4.3
 # org.ajoberstar.git-publish
 gitPublishVersion=2.1.3
 # org.junit.jupiter:junit-jupiter-api
-junitJupiterVersion=5.7.1
+junitJupiterVersion=5.7.2
 # org.amshove.kluent
 kluentVersion=1.65
 kotlinVersion=1.4.32

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,6 @@ rxjavaVersion=2.2.21
 # io.reactivex.rxjava2:rxkotlin
 rxkotlinVersion=2.4.0
 # org.spekframework.spek2:spek-dsl-jvm
-spekVersion=2.0.15
+spekVersion=2.0.17
 
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=1G

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ group=ch.difty.kris
 # org.assertj:assertj-core
 assertjVersion=3.20.2
 # org.jetbrains.kotlinx:kotlinx-coroutines-core
-coroutinesVersion=1.5.0
+coroutinesVersion=1.5.1
 # org.ajoberstar.git-publish
 gitPublishVersion=2.1.3
 # org.junit.jupiter:junit-jupiter-api

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ gitPublishVersion=2.1.3
 # org.junit.jupiter:junit-jupiter-api
 junitJupiterVersion=5.7.2
 # org.amshove.kluent
-kluentVersion=1.67
+kluentVersion=1.68
 kotlinVersion=1.5.21
 kordampPluginVersion=0.46.0
 # io.mockk:mockk

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ junitJupiterVersion=5.7.1
 # org.amshove.kluent
 kluentVersion=1.65
 kotlinVersion=1.4.32
-kordampPluginVersion=0.45.0
+kordampPluginVersion=0.46.0
 # io.mockk:mockk
 mockkVersion=1.11.0
 # org.ajoberstar.reckon

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ group=ch.difty.kris
 # org.assertj:assertj-core
 assertjVersion=3.21.0
 # org.jetbrains.kotlinx:kotlinx-coroutines-core
-coroutinesVersion=1.5.1
+coroutinesVersion=1.6.0
 # org.ajoberstar.git-publish
 gitPublishVersion=2.1.3
 # org.junit.jupiter:junit-jupiter-api

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ coroutinesVersion=1.5.1
 # org.ajoberstar.git-publish
 gitPublishVersion=2.1.3
 # org.junit.jupiter:junit-jupiter-api
-junitJupiterVersion=5.7.2
+junitJupiterVersion=5.8.2
 # org.amshove.kluent
 kluentVersion=1.68
 kotlinVersion=1.5.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 group=ch.difty.kris
 
 # org.assertj:assertj-core
-assertjVersion=3.19.0
+assertjVersion=3.20.2
 # org.jetbrains.kotlinx:kotlinx-coroutines-core
 coroutinesVersion=1.5.0
 # org.ajoberstar.git-publish

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/subprojects/kris-core/src/main/kotlin/ch/difty/kris/KRis.kt
+++ b/subprojects/kris-core/src/main/kotlin/ch/difty/kris/KRis.kt
@@ -6,7 +6,9 @@ import ch.difty.kris.domain.RisRecord
 import ch.difty.kris.implementation.RisExport
 import ch.difty.kris.implementation.RisImport
 import io.reactivex.Observable
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.toList
@@ -31,7 +33,8 @@ internal const val TAG_SEPARATOR = "  - "
  * @author Urs Joss - urs.joss@gmx.ch
  */
 @Suppress("KDocUnresolvedReference")
-@ExperimentalCoroutinesApi
+
+@OptIn(ExperimentalCoroutinesApi::class)
 public object KRis {
 
 //region:process - RISFile lines -> RisRecords

--- a/subprojects/kris-core/src/main/kotlin/ch/difty/kris/KRis.kt
+++ b/subprojects/kris-core/src/main/kotlin/ch/difty/kris/KRis.kt
@@ -6,9 +6,7 @@ import ch.difty.kris.domain.RisRecord
 import ch.difty.kris.implementation.RisExport
 import ch.difty.kris.implementation.RisImport
 import io.reactivex.Observable
-import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.toList

--- a/subprojects/kris-core/src/main/kotlin/ch/difty/kris/KRisExtensions.kt
+++ b/subprojects/kris-core/src/main/kotlin/ch/difty/kris/KRisExtensions.kt
@@ -1,4 +1,5 @@
 @file:Suppress("SpellCheckingInspection", "RedundantVisibilityModifier")
+@file:OptIn(ExperimentalCoroutinesApi::class)
 
 package ch.difty.kris
 
@@ -24,23 +25,19 @@ import java.nio.channels.ClosedChannelException
  * Converts a flow of Strings (representing lines in a RIS file) (as receiver) into a flow of [RisRecord]s.
  * May throw a [KRisException] if the line flow cannot be parsed successfully.
  */
-@ExperimentalCoroutinesApi
 public fun Flow<String>.toRisRecords(): Flow<RisRecord> = KRis.process(this)
 
 /**
  * Converts a list of Strings (representing lines in a RIS file) (as receiver) itno a list of [RisRecord]s.
  * May throw a [KRisException] if the line list of Strings cannot be parsed successfully.
  */
-@ExperimentalCoroutinesApi
 public fun List<String>.toRisRecords(): List<RisRecord> = KRis.processList(this)
 
 /**
  * Converts a sequence of Strings (representing lines in a RIS file) (as receiver) into a sequence of [RisRecord]s
  * in a blocking manner. May throw a [KRisException] if the line flow cannot be parsed successfully.
  */
-@FlowPreview
-@ExperimentalCoroutinesApi
-@DelicateCoroutinesApi
+@OptIn(FlowPreview::class, DelicateCoroutinesApi::class)
 public fun Sequence<String>.toRisRecords(scope: CoroutineScope = GlobalScope): Sequence<RisRecord> = mapSequence(KRis::process, scope)
 //endregion
 
@@ -51,7 +48,6 @@ public fun Sequence<String>.toRisRecords(scope: CoroutineScope = GlobalScope): S
  * Optionally accepts a list of names of RisTags defining a sort order for the RisTags in the file.
  */
 @JvmOverloads
-@ExperimentalCoroutinesApi
 public fun Flow<RisRecord>.toRisLines(sort: List<String> = emptyList()): Flow<String> = KRis.build(this, sort)
 
 /**
@@ -59,16 +55,13 @@ public fun Flow<RisRecord>.toRisLines(sort: List<String> = emptyList()): Flow<St
  * Optionally accepts a list of names of RisTags defining a sort order for the RisTags in the file.
  */
 @JvmOverloads
-@ExperimentalCoroutinesApi
 public fun List<RisRecord>.toRisLines(sort: List<String> = emptyList()): List<String> =
     runBlocking { asFlow().toRisLines(sort).toList() }
 
 /**
  * Processes a sequence of [RisRecord]s into a sequence of Strings representing lines in RIS file format.
  */
-@FlowPreview
-@ExperimentalCoroutinesApi
-@DelicateCoroutinesApi
+@OptIn(FlowPreview::class, DelicateCoroutinesApi::class)
 public fun Sequence<RisRecord>.toRisLines(scope: CoroutineScope = GlobalScope): Sequence<String> = mapSequence(KRis::build, scope)
 //endregion
 
@@ -77,8 +70,7 @@ public fun Sequence<RisRecord>.toRisLines(scope: CoroutineScope = GlobalScope): 
  * accepting a flow of type [T] and returning a flow of type [R].
  * Thanks to @jcornaz for the help.
  */
-@FlowPreview
-@ExperimentalCoroutinesApi
+@OptIn(FlowPreview::class)
 private fun <T, R> Sequence<T>.mapSequence(
     flowMapper: (Flow<T>) -> Flow<R>,
     scope: CoroutineScope

--- a/subprojects/kris-core/src/main/kotlin/ch/difty/kris/implementation/RisExport.kt
+++ b/subprojects/kris-core/src/main/kotlin/ch/difty/kris/implementation/RisExport.kt
@@ -5,7 +5,6 @@ import ch.difty.kris.domain.RisRecord
 import ch.difty.kris.domain.RisTag
 import ch.difty.kris.truncatedTo
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 
 private const val INT_INTERMEDIATE = 1000

--- a/subprojects/kris-core/src/main/kotlin/ch/difty/kris/implementation/RisImport.kt
+++ b/subprojects/kris-core/src/main/kotlin/ch/difty/kris/implementation/RisImport.kt
@@ -54,7 +54,7 @@ internal object RisImport {
         return tag
     }
 
-    private fun RisTag.typeSafeValueFrom(line: String): Any? {
+    private fun RisTag.typeSafeValueFrom(line: String): Any {
         val rawValue: String = line.substring(START_INDEX_VALUE).trim()
         return when (kClass) {
             RisType::class -> RisType.valueOf(rawValue)

--- a/subprojects/kris-core/src/main/kotlin/ch/difty/kris/implementation/RisImport.kt
+++ b/subprojects/kris-core/src/main/kotlin/ch/difty/kris/implementation/RisImport.kt
@@ -7,7 +7,6 @@ import ch.difty.kris.domain.RisTag
 import ch.difty.kris.domain.RisType
 import ch.difty.kris.truncatedTo
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flow

--- a/subprojects/kris-core/src/test/kotlin/ch/difty/kris/KRisProcessFromListTest.kt
+++ b/subprojects/kris-core/src/test/kotlin/ch/difty/kris/KRisProcessFromListTest.kt
@@ -5,6 +5,7 @@ package ch.difty.kris
 import ch.difty.kris.domain.RisRecord
 import ch.difty.kris.domain.RisType
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
@@ -185,9 +186,9 @@ class KRisProcessFromListTest {
         |ER  - 
         |""".trimMargin()
 
-    @ExperimentalCoroutinesApi
-    @Test
     @Suppress("S100")
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
     fun `can build risRecord with all fields`() {
         val lines = KRis.buildFromList(listOf(risRecord))
         lines.joinToString("") shouldBeEqualTo expected

--- a/subprojects/kris-core/src/test/kotlin/ch/difty/kris/KRisProcessingSpec.kt
+++ b/subprojects/kris-core/src/test/kotlin/ch/difty/kris/KRisProcessingSpec.kt
@@ -1,7 +1,9 @@
 package ch.difty.kris
 
 import ch.difty.kris.domain.RisType
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
@@ -12,7 +14,7 @@ import org.amshove.kluent.shouldThrow
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
-@ExperimentalCoroutinesApi
+@OptIn(ExperimentalCoroutinesApi::class)
 @Suppress("unused", "SpellCheckingInspection", "S1192")
 object KRisProcessingSpec : Spek({
 

--- a/subprojects/kris-core/src/test/kotlin/ch/difty/kris/usage/KRisUsageSpec.kt
+++ b/subprojects/kris-core/src/test/kotlin/ch/difty/kris/usage/KRisUsageSpec.kt
@@ -6,6 +6,7 @@ import ch.difty.kris.domain.RisType
 import ch.difty.kris.risTagNames
 import ch.difty.kris.toRisLines
 import ch.difty.kris.toRisRecords
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.InternalCoroutinesApi
@@ -21,6 +22,7 @@ import org.spekframework.spek2.style.specification.describe
 /**
  * Specification how to use KRis from kotlin
  */
+@DelicateCoroutinesApi
 @ExperimentalCoroutinesApi
 @FlowPreview
 @Suppress("SpellCheckingInspection", "unused")

--- a/subprojects/kris-core/src/test/kotlin/ch/difty/kris/usage/KRisUsageSpec.kt
+++ b/subprojects/kris-core/src/test/kotlin/ch/difty/kris/usage/KRisUsageSpec.kt
@@ -22,11 +22,8 @@ import org.spekframework.spek2.style.specification.describe
 /**
  * Specification how to use KRis from kotlin
  */
-@DelicateCoroutinesApi
-@ExperimentalCoroutinesApi
-@FlowPreview
 @Suppress("SpellCheckingInspection", "unused")
-@InternalCoroutinesApi
+@OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class, DelicateCoroutinesApi::class, InternalCoroutinesApi::class)
 object KRisUsageSpec : Spek({
 
     describe("with list of strings representing two RIS records") {

--- a/subprojects/kris-guide/src/test/kotlin/ch/difty/kris/guide/GuideExamples.kt
+++ b/subprojects/kris-guide/src/test/kotlin/ch/difty/kris/guide/GuideExamples.kt
@@ -9,8 +9,10 @@ import ch.difty.kris.process
 import ch.difty.kris.risTagNames
 import ch.difty.kris.toRisLines
 import ch.difty.kris.toRisRecords
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
@@ -195,12 +197,13 @@ fun passRisLinesAsList() {
 
 @ExperimentalCoroutinesApi
 @FlowPreview
+@DelicateCoroutinesApi
 @Suppress("UNUSED_VARIABLE", "UNREACHABLE_CODE")
 fun passRisLinesAsSequence() {
     // tag::passRisLinesAsSequence[]
     val lineSequence: Sequence<String> = TODO()
 
-    val records: Sequence<RisRecord> = lineSequence.toRisRecords()
+    val records: Sequence<RisRecord> = lineSequence.toRisRecords(GlobalScope)
     // end::passRisLinesAsSequence[]
 }
 

--- a/subprojects/kris-guide/src/test/kotlin/ch/difty/kris/guide/GuideExamples.kt
+++ b/subprojects/kris-guide/src/test/kotlin/ch/difty/kris/guide/GuideExamples.kt
@@ -1,4 +1,5 @@
 @file:Suppress("unused", "SpellCheckingInspection", "UNUSED_VARIABLE", "RedundantExplicitType")
+@file: OptIn(ExperimentalCoroutinesApi::class)
 
 package ch.difty.kris.guide
 
@@ -49,7 +50,6 @@ val record2 = RisRecord(
 )
 // end::risRecords[]
 
-@ExperimentalCoroutinesApi
 fun listToRisLines() {
     // tag::listToRisLines[]
     val lines: List<String> = listOf(record1, record2).toRisLines()
@@ -57,7 +57,6 @@ fun listToRisLines() {
 }
 
 @Suppress("UNUSED_VARIABLE")
-@ExperimentalCoroutinesApi
 fun listToRisLinesWithSort() {
     // tag::listToRisLinesWithSort[]
     val sort: List<String> = listOf("SP", "EP", "T1")
@@ -72,7 +71,6 @@ fun getListOfRisTagsAsString() {
     // end::getListOfRisTagsAsString[]
 }
 
-@ExperimentalCoroutinesApi
 fun writingToFileManually() {
     // tag::writingToFileManually[]
     val lines: List<String> = listOf(record1, record2).toRisLines()
@@ -83,7 +81,6 @@ fun writingToFileManually() {
     // end::writingToFileManually[]
 }
 
-@ExperimentalCoroutinesApi
 fun writerAccept() {
     // tag::writerAccept[]
     val writer = File.createTempFile("export.ris", null, null).bufferedWriter()
@@ -92,7 +89,6 @@ fun writerAccept() {
     // end::writerAccept[]
 }
 
-@ExperimentalCoroutinesApi
 fun fileAccept() {
     // tag::fileAccept[]
     val file = File.createTempFile("export.ris", null, null)
@@ -101,7 +97,6 @@ fun fileAccept() {
     // end::fileAccept[]
 }
 
-@ExperimentalCoroutinesApi
 fun streamAccept() {
     // tag::streamAccept[]
     val outputStream = File.createTempFile("export.ris", null, null).outputStream()
@@ -110,7 +105,6 @@ fun streamAccept() {
     // end::streamAccept[]
 }
 
-@ExperimentalCoroutinesApi
 fun pathAccept() {
     // tag::pathAccept[]
     "export.ris".accept(listOf(record1, record2))
@@ -118,7 +112,6 @@ fun pathAccept() {
 }
 
 @Suppress("UNUSED_VARIABLE")
-@ExperimentalCoroutinesApi
 fun flowToRisLines() {
     // tag::flowToRisLines[]
     val flow = flowOf(record1, record2)
@@ -127,7 +120,6 @@ fun flowToRisLines() {
     // end::flowToRisLines[]
 }
 
-@ExperimentalCoroutinesApi
 fun pathAcceptFlow() {
     // tag::pathAcceptFlow[]
     val risLines: Flow<String> = flowOf(record1, record2).toRisLines()
@@ -143,7 +135,6 @@ fun pathAcceptFlow() {
 
 //region file-records
 
-@ExperimentalCoroutinesApi
 @Suppress("UNUSED_VARIABLE")
 fun processReader() {
     // tag::processReader[]
@@ -154,7 +145,6 @@ fun processReader() {
 }
 //endregion
 
-@ExperimentalCoroutinesApi
 @Suppress("UNUSED_VARIABLE")
 fun processFile() {
     // tag::processFile[]
@@ -165,7 +155,6 @@ fun processFile() {
 }
 //endregion
 
-@ExperimentalCoroutinesApi
 @Suppress("UNUSED_VARIABLE")
 fun processInputStream() {
     // tag::processInputStream[]
@@ -176,7 +165,6 @@ fun processInputStream() {
 }
 //endregion
 
-@ExperimentalCoroutinesApi
 @Suppress("UNUSED_VARIABLE")
 fun processPath() {
     // tag::processPath[]
@@ -184,8 +172,7 @@ fun processPath() {
     // end::processPath[]
 }
 
-@ExperimentalCoroutinesApi
-@FlowPreview
+@OptIn(FlowPreview::class)
 @Suppress("UNUSED_VARIABLE", "UNREACHABLE_CODE")
 fun passRisLinesAsList() {
     // tag::passRisLinesAsList[]
@@ -195,9 +182,7 @@ fun passRisLinesAsList() {
     // end::passRisLinesAsList[]
 }
 
-@ExperimentalCoroutinesApi
-@FlowPreview
-@DelicateCoroutinesApi
+@OptIn(FlowPreview::class, DelicateCoroutinesApi::class)
 @Suppress("UNUSED_VARIABLE", "UNREACHABLE_CODE")
 fun passRisLinesAsSequence() {
     // tag::passRisLinesAsSequence[]
@@ -207,8 +192,7 @@ fun passRisLinesAsSequence() {
     // end::passRisLinesAsSequence[]
 }
 
-@ExperimentalCoroutinesApi
-@FlowPreview
+@OptIn(FlowPreview::class)
 @Suppress("UNUSED_VARIABLE", "UNREACHABLE_CODE")
 fun passRisLinesAsFlow() {
     // tag::passRisLinesAsFlow[]

--- a/subprojects/kris-io/src/integrationTest/java/ch/difty/kris/KRisIOIntegrationTest.kt
+++ b/subprojects/kris-io/src/integrationTest/java/ch/difty/kris/KRisIOIntegrationTest.kt
@@ -3,6 +3,7 @@ package ch.difty.kris
 import ch.difty.kris.domain.RisRecord
 import ch.difty.kris.domain.RisType
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.InternalCoroutinesApi
 import org.amshove.kluent.shouldContainAll
 import org.amshove.kluent.shouldHaveSize
 import org.junit.jupiter.api.Test
@@ -11,7 +12,7 @@ import java.io.File
 private const val FILE_PATH = "src/integrationTest/resources/sample.ris"
 private const val PAPER_COUNT = 3
 
-@ExperimentalCoroutinesApi
+@OptIn(ExperimentalCoroutinesApi::class)
 @Suppress("FunctionName", "S100", "SpellCheckingInspection")
 internal class KRisIOIntegrationTest {
 

--- a/subprojects/kris-io/src/integrationTest/kotlin/ch/difty/kris/usage/KRisIoUsageExportSpec.kt
+++ b/subprojects/kris-io/src/integrationTest/kotlin/ch/difty/kris/usage/KRisIoUsageExportSpec.kt
@@ -11,9 +11,8 @@ import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.io.File
 
-@ExperimentalCoroutinesApi
 @Suppress("SpellCheckingInspection")
-@InternalCoroutinesApi
+@OptIn(ExperimentalCoroutinesApi::class, InternalCoroutinesApi::class)
 object KRisIoUsageExportSpec : Spek({
 
     describe("exporting into file") {
@@ -45,7 +44,7 @@ object KRisIoUsageExportSpec : Spek({
     }
 })
 
-@ExperimentalCoroutinesApi
+@OptIn(ExperimentalCoroutinesApi::class)
 private fun List<RisRecord>.assertRecordsWereWrittenTo(file: File) {
     file.path.process() shouldHaveSize size
 }

--- a/subprojects/kris-io/src/integrationTest/kotlin/ch/difty/kris/usage/KRisIoUsageImportSpec.kt
+++ b/subprojects/kris-io/src/integrationTest/kotlin/ch/difty/kris/usage/KRisIoUsageImportSpec.kt
@@ -11,9 +11,8 @@ import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.io.File
 
-@ExperimentalCoroutinesApi
 @Suppress("SpellCheckingInspection")
-@InternalCoroutinesApi
+@OptIn(ExperimentalCoroutinesApi::class, InternalCoroutinesApi::class)
 object KRisIoUsageImportSpec : Spek({
 
     describe("importing from file") {

--- a/subprojects/kris-io/src/integrationTest/kotlin/ch/difty/kris/usage/KRisIoUsageSpec.kt
+++ b/subprojects/kris-io/src/integrationTest/kotlin/ch/difty/kris/usage/KRisIoUsageSpec.kt
@@ -5,7 +5,9 @@ import ch.difty.kris.accept
 import ch.difty.kris.domain.RisRecord
 import ch.difty.kris.domain.RisType
 import ch.difty.kris.process
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.InternalCoroutinesApi
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldHaveSize
@@ -14,8 +16,7 @@ import org.spekframework.spek2.style.specification.describe
 import java.io.File
 
 @Suppress("SpellCheckingInspection", "unused")
-@InternalCoroutinesApi
-@ExperimentalCoroutinesApi
+@OptIn(ExperimentalCoroutinesApi::class, InternalCoroutinesApi::class)
 object KRisIoUsageSpec : Spek({
 
     describe("importing from file") {

--- a/subprojects/kris-io/src/main/kotlin/ch/difty/kris/ExportExtensions.kt
+++ b/subprojects/kris-io/src/main/kotlin/ch/difty/kris/ExportExtensions.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
 package ch.difty.kris
 
 import ch.difty.kris.domain.RisRecord
@@ -11,7 +13,7 @@ import java.io.Writer
  * [Writer] provided as receiver. Optionally accepts a list of names of RisTags defining a sort order for
  * the RisTags in the file.
  */
-@ExperimentalCoroutinesApi
+
 public fun Writer.accept(records: List<RisRecord>, sort: List<String> = emptyList()): Unit = KRisIO.export(records, sort, this)
 
 /**
@@ -19,7 +21,6 @@ public fun Writer.accept(records: List<RisRecord>, sort: List<String> = emptyLis
  * provided as receiver. Optionally accepts a list of names of RisTags defining a sort order for the RisTags
  * in the file.
  */
-@ExperimentalCoroutinesApi
 public fun File.accept(records: List<RisRecord>, sort: List<String> = emptyList()): Unit = KRisIO.export(records, sort, this)
 
 /**
@@ -27,7 +28,6 @@ public fun File.accept(records: List<RisRecord>, sort: List<String> = emptyList(
  * the [OutputStream] provided as receiver. Optionally accepts a list of names of RisTags defining a sort order
  * for the RisTags in the file.
  */
-@ExperimentalCoroutinesApi
 public fun OutputStream.accept(records: List<RisRecord>, sort: List<String> = emptyList()): Unit = KRisIO.export(records, sort, this)
 
 /**
@@ -35,5 +35,4 @@ public fun OutputStream.accept(records: List<RisRecord>, sort: List<String> = em
  * the path provided as the receiver, if possible.
  * Optionally accepts a list of names of RisTags defining a sort order for the RisTags in the file.
  */
-@ExperimentalCoroutinesApi
 public fun String.accept(records: List<RisRecord>, sort: List<String> = emptyList()): Unit = KRisIO.export(records, sort, this)

--- a/subprojects/kris-io/src/main/kotlin/ch/difty/kris/ImportExtensions.kt
+++ b/subprojects/kris-io/src/main/kotlin/ch/difty/kris/ImportExtensions.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
 package ch.difty.kris
 
 import ch.difty.kris.domain.RisRecord
@@ -12,7 +14,7 @@ import java.io.Reader
  * May throw an [IOException] if the reader fails to deliver lines or a [KRisException]
  * if the lines cannot be parsed successfully.
  */
-@ExperimentalCoroutinesApi
+
 public fun Reader.process(): List<RisRecord> = KRisIO.process(this)
 
 /**
@@ -20,7 +22,6 @@ public fun Reader.process(): List<RisRecord> = KRisIO.process(this)
  * May throw an [IOException] if the file cannot be read successfully.
  * or a [KRisException] if the lines cannot be parsed successfully.
  */
-@ExperimentalCoroutinesApi
 public fun File.process(): List<RisRecord> = KRisIO.process(this)
 
 /**
@@ -28,7 +29,6 @@ public fun File.process(): List<RisRecord> = KRisIO.process(this)
  * May throw an [IOException] if the file cannot be read successfully.
  * or a [KRisException] if the lines cannot be parsed successfully.
  */
-@ExperimentalCoroutinesApi
 public fun String.process(): List<RisRecord> = KRisIO.process(this)
 
 /**
@@ -36,5 +36,4 @@ public fun String.process(): List<RisRecord> = KRisIO.process(this)
  * May throw an [IOException] if the stream cannot be read successfully.
  * or a [KRisException] if the lines cannot be parsed successfully.
  */
-@ExperimentalCoroutinesApi
 public fun InputStream.process(): List<RisRecord> = KRisIO.process(this)

--- a/subprojects/kris-io/src/main/kotlin/ch/difty/kris/KRisIO.kt
+++ b/subprojects/kris-io/src/main/kotlin/ch/difty/kris/KRisIO.kt
@@ -20,6 +20,7 @@ import java.io.Writer
 /**
  * Convenience methods offering to directly work with IO methods.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 public object KRisIO {
 
     //region:process -> RISFile lines -> RisRecords
@@ -30,7 +31,6 @@ public object KRisIO {
      * or a [KRisException] if the lines cannot be parsed successfully.
      */
     @JvmStatic
-    @ExperimentalCoroutinesApi
     @Throws(IOException::class)
     public fun process(reader: Reader): List<RisRecord> = runBlocking(Dispatchers.IO) {
         val lineFlow = BufferedReader(reader).readLines().asFlow()
@@ -43,7 +43,6 @@ public object KRisIO {
      * or a [KRisException] if the lines cannot be parsed successfully.
      */
     @JvmStatic
-    @ExperimentalCoroutinesApi
     @Throws(IOException::class)
     public fun process(file: File): List<RisRecord> = process(file.bufferedReader())
 
@@ -53,7 +52,6 @@ public object KRisIO {
      * or a [KRisException] if the lines cannot be parsed successfully.
      */
     @JvmStatic
-    @ExperimentalCoroutinesApi
     @Throws(IOException::class)
     public fun process(filePath: String): List<RisRecord> = process(File(filePath).bufferedReader())
 
@@ -63,7 +61,6 @@ public object KRisIO {
      * or a [KRisException] if the lines cannot be parsed successfully.
      */
     @JvmStatic
-    @ExperimentalCoroutinesApi
     @Throws(IOException::class)
     public fun process(inputStream: InputStream): List<RisRecord> = process(inputStream.bufferedReader())
 
@@ -78,7 +75,6 @@ public object KRisIO {
      */
     @JvmStatic
     @JvmOverloads
-    @ExperimentalCoroutinesApi
     public fun export(records: List<RisRecord>, sort: List<String> = emptyList(), writer: Writer) {
         writer.use { w ->
             runBlocking(Dispatchers.IO) {
@@ -96,7 +92,6 @@ public object KRisIO {
      */
     @JvmStatic
     @JvmOverloads
-    @ExperimentalCoroutinesApi
     public fun export(records: List<RisRecord>, sort: List<String> = emptyList(), file: File) {
         FileWriter(file).use { fileWriter ->
             export(records, sort, fileWriter)
@@ -110,7 +105,6 @@ public object KRisIO {
      */
     @JvmStatic
     @JvmOverloads
-    @ExperimentalCoroutinesApi
     public fun export(records: List<RisRecord>, sort: List<String> = emptyList(), out: OutputStream) {
         OutputStreamWriter(out).use { writer ->
             export(records, sort, writer)
@@ -124,7 +118,6 @@ public object KRisIO {
      */
     @JvmStatic
     @JvmOverloads
-    @ExperimentalCoroutinesApi
     public fun export(records: List<RisRecord>, sort: List<String> = emptyList(), filePath: String) {
         FileOutputStream(filePath).use {
             export(records, sort, it)


### PR DESCRIPTION
Open issues:
- [x] Delicate API in KRisExtensions.kt
- [x] cannot inline bytecode built with JVM target 1.8 into bytecode that is being built with JVM target 1.6

<details><summary>Delicate API in KRisExtensions.kt</summary>
<pre>
w: /home/urs/work/git/priv/KRis/subprojects/kris-core/src/main/kotlin/ch/difty/kris/KRisExtensions.kt: (43, 56): This is a delicate API and its use requires care. Make sure you fully read and understand documentation of the declaration that is marked as a delicate API.
w: /home/urs/work/git/priv/KRis/subprojects/kris-core/src/main/kotlin/ch/difty/kris/KRisExtensions.kt: (86, 54): This is a delicate API and its use requires care. Make sure you fully read and understand documentation of the declaration that is marked as a delicate API.
</pre>
</details>

Occuring for task `gw aggregateDetekt`:

<details><summary>cannot inline bytecode built with JVM target 1.8 into bytecode that is being built with JVM target 1.6</summary>
<pre>
w: /home/urs/work/git/priv/KRis/subprojects/kris-core/src/main/kotlin/ch/difty/kris/KRisExtensions.kt: (43, 56): This is a delicate API and its use requires care. Make sure you fully read and understand documentation of the declaration that is marked as a delicate API.
w: /home/urs/work/git/priv/KRis/subprojects/kris-core/src/main/kotlin/ch/difty/kris/KRisExtensions.kt: (86, 54): This is a delicate API and its use requires care. Make sure you fully read and understand documentation of the declaration that is marked as a delicate API.

//home/urs/work/git/priv/KRis/subprojects/kris-core/src/main/kotlin/ch/difty/kris/implementation/RisExport.kt:25:20: error: cannot inline bytecode built with JVM target 1.8 into bytecode that is being built with JVM target 1.6. Please specify proper '-jvm-target' option
        recordFlow.collect { risRecord ->
                   ^
//home/urs/work/git/priv/KRis/subprojects/kris-core/src/main/kotlin/ch/difty/kris/implementation/RisImport.kt:28:14: error: cannot inline bytecode built with JVM target 1.8 into bytecode that is being built with JVM target 1.6. Please specify proper '-jvm-target' option
            .filterNot { line -> line.isEmpty() }
             ^
//home/urs/work/git/priv/KRis/subprojects/kris-core/src/main/kotlin/ch/difty/kris/implementation/RisImport.kt:29:14: error: cannot inline bytecode built with JVM target 1.8 into bytecode that is being built with JVM target 1.6. Please specify proper '-jvm-target' option
            .collect { line ->
</pre>
</details>