### PR TITLE
cleanup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,10 @@ plugins {
     jacoco
 }
 
+java {
+    toolchain.languageVersion.set(JavaLanguageVersion.of(libs.versions.java.get()))
+}
+
 reckon {
     stages("rc", "final")
     setScopeCalc(calcScopeFromProp().or(calcScopeFromCommitMessages()))

--- a/gradle-plugins/publishing/build.gradle.kts
+++ b/gradle-plugins/publishing/build.gradle.kts
@@ -10,7 +10,7 @@ dependencies {
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile::class.java).configureEach {
-    kotlinOptions.jvmTarget = JavaVersion.VERSION_11.name
+    kotlinOptions.jvmTarget = libs.versions.java.get()
 }
 
 detekt {

--- a/gradle-plugins/verification/build.gradle.kts
+++ b/gradle-plugins/verification/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile
+
 plugins {
     `java-gradle-plugin`
     `kotlin-dsl`
@@ -9,8 +11,8 @@ dependencies {
     implementation(libs.plugin.detekt)
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile::class.java).configureEach {
-    kotlinOptions.jvmTarget = JavaVersion.VERSION_11.name
+tasks.withType(KotlinJvmCompile::class.java).configureEach {
+    kotlinOptions.jvmTarget = libs.versions.java.get()
 }
 
 detekt {

--- a/subprojects/kris-core/src/test/kotlin/ch/difty/kris/KRisProcessFromListTest.kt
+++ b/subprojects/kris-core/src/test/kotlin/ch/difty/kris/KRisProcessFromListTest.kt
@@ -4,7 +4,6 @@ package ch.difty.kris
 
 import ch.difty.kris.domain.RisRecord
 import ch.difty.kris.domain.RisType
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 

--- a/subprojects/kris-guide/kris-guide.gradle.kts
+++ b/subprojects/kris-guide/kris-guide.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 tasks {
     withType<KotlinCompile>().configureEach {
         kotlinOptions {
-            jvmTarget = JavaVersion.VERSION_11.toString()
+            jvmTarget = libs.versions.java.get()
         }
     }
 }

--- a/subprojects/kris-guide/src/test/kotlin/ch/difty/kris/guide/GuideExamples.kt
+++ b/subprojects/kris-guide/src/test/kotlin/ch/difty/kris/guide/GuideExamples.kt
@@ -10,8 +10,6 @@ import ch.difty.kris.risTagNames
 import ch.difty.kris.toRisLines
 import ch.difty.kris.toRisRecords
 import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
@@ -171,7 +169,6 @@ fun processPath() {
     // end::processPath[]
 }
 
-@OptIn(FlowPreview::class)
 @Suppress("UNUSED_VARIABLE", "UNREACHABLE_CODE")
 fun passRisLinesAsList() {
     // tag::passRisLinesAsList[]
@@ -181,7 +178,7 @@ fun passRisLinesAsList() {
     // end::passRisLinesAsList[]
 }
 
-@OptIn(FlowPreview::class, DelicateCoroutinesApi::class)
+@OptIn(DelicateCoroutinesApi::class)
 @Suppress("UNUSED_VARIABLE", "UNREACHABLE_CODE")
 fun passRisLinesAsSequence() {
     // tag::passRisLinesAsSequence[]
@@ -191,7 +188,6 @@ fun passRisLinesAsSequence() {
     // end::passRisLinesAsSequence[]
 }
 
-@OptIn(FlowPreview::class)
 @Suppress("UNUSED_VARIABLE", "UNREACHABLE_CODE")
 fun passRisLinesAsFlow() {
     // tag::passRisLinesAsFlow[]


### PR DESCRIPTION
- unify the various java source/target/version declarations to use the java version from lib
- remove a couple of opt-ins that are not need anymore