### PR TITLE
chore: Migrate to gradle 8.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
           path: '**/build/reports'
 
       - name: Run all tests with Gradle
-        run: ./gradlew check detekt sonar --info --no-daemon
+        run: ./gradlew check detekt --info --no-daemon
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,7 +92,6 @@ subprojects.forEach { subProject ->
             kotlinOptions {
                 apiVersion = kotlinApiLangVersion
                 languageVersion = kotlinApiLangVersion
-                freeCompilerArgs = freeCompilerArgs + listOf("-opt-in=kotlin.RequiresOptIn")
             }
         }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,10 +24,6 @@ plugins {
     jacoco
 }
 
-java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(libs.versions.java.get()))
-}
-
 reckon {
     stages("rc", "final")
     setScopeCalc(calcScopeFromProp().or(calcScopeFromCommitMessages()))
@@ -92,18 +88,12 @@ subprojects.forEach { subProject ->
     subProject.tasks {
         val kotlinVersion = libs.versions.kotlin.get()
         val kotlinApiLangVersion = kotlinVersion.subSequence(0, 3).toString()
-        val jvmTargetVersion = libs.versions.java.get()
         withType<KotlinCompile>().configureEach {
             kotlinOptions {
                 apiVersion = kotlinApiLangVersion
                 languageVersion = kotlinApiLangVersion
-                jvmTarget = jvmTargetVersion
                 freeCompilerArgs = freeCompilerArgs + listOf("-opt-in=kotlin.RequiresOptIn")
             }
-        }
-        withType<JavaCompile>().configureEach {
-            sourceCompatibility = jvmTargetVersion
-            targetCompatibility = jvmTargetVersion
         }
 
         withType<Test> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -82,6 +84,14 @@ tasks {
     }
 }
 
+testing {
+    suites {
+        val test by getting(JvmTestSuite::class) {
+            useJUnitJupiter()
+        }
+    }
+}
+
 val kotlinSrcSet = "/src/main/kotlin"
 
 subprojects.forEach { subProject ->
@@ -95,11 +105,6 @@ subprojects.forEach { subProject ->
             }
         }
 
-        withType<Test> {
-            useJUnitPlatform {
-                includeEngines("junit-jupiter", "kotest")
-            }
-        }
         withType<DokkaTaskPartial>().configureEach {
             dokkaSourceSets {
                 configureEach {

--- a/gradle-plugins/build.gradle.kts
+++ b/gradle-plugins/build.gradle.kts
@@ -1,3 +1,11 @@
+plugins {
+    kotlin("jvm") version "1.8.10"
+}
+
+kotlin {
+    jvmToolchain(11)
+}
+
 val buildTask = tasks.register("buildPlugins")
 
 subprojects {

--- a/gradle-plugins/publishing/build.gradle.kts
+++ b/gradle-plugins/publishing/build.gradle.kts
@@ -9,10 +9,6 @@ dependencies {
     implementation(libs.plugin.detekt)
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile::class.java).configureEach {
-    kotlinOptions.jvmTarget = libs.versions.java.get()
-}
-
 detekt {
     buildUponDefaultConfig = true
     config.from(file("../../config/detekt/detekt.yml"))

--- a/gradle-plugins/verification/build.gradle.kts
+++ b/gradle-plugins/verification/build.gradle.kts
@@ -11,10 +11,6 @@ dependencies {
     implementation(libs.plugin.detekt)
 }
 
-tasks.withType(KotlinJvmCompile::class.java).configureEach {
-    kotlinOptions.jvmTarget = libs.versions.java.get()
-}
-
 detekt {
     buildUponDefaultConfig = true
     config.from(file("../../config/detekt/detekt.yml"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,6 @@ nexusPublish = "1.1.0"
 reckon = "0.16.1"
 rxjava = "2.2.21"
 sonarqube = "3.5.0.2730"
-testSets = "4.0.0"
 versions = "0.45.0"
 
 [libraries]
@@ -40,8 +39,7 @@ plugin-reckon = { module = "org.ajoberstar.reckon:reckon-gradle", version.ref = 
 
 [bundles]
 kotlin = ["kotlin-stdlib", "kotlin-reflect", "coroutines-core"]
-testDeps = ["junitJupiter-api", "kotest-framework-api", "mockk", "kluent", "assertj-core"]
-testEngines = ["junitJupiter-engine", "kotest-runner-junit5"]
+testDeps = ["junitJupiter-api", "kotest-runner-junit5", "kotest-framework-api", "mockk", "kluent", "assertj-core"]
 
 [plugins]
 asciidoctorConvert = { id = "org.asciidoctor.jvm.convert", version.ref = "asciidoctor" }
@@ -51,5 +49,4 @@ gitPublish = { id = "org.ajoberstar.git-publish", version.ref = "gitPublish" }
 nexusPublish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexusPublish" }
 reckon = { id = "org.ajoberstar.reckon", version.ref = "reckon" }
 sonarqube = { id = "org.sonarqube", version.ref = "sonarqube" }
-testSets = { id = "org.unbroken-dome.test-sets", version.ref = "testSets" }
 versions = { id = "com.github.ben-manes.versions", version.ref = "versions" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/subprojects/kris-core/kris-core.gradle.kts
+++ b/subprojects/kris-core/kris-core.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
 
 kotlin {
     explicitApi()
+    jvmToolchain(libs.versions.java.get().toInt())
 }
 
 tasks {

--- a/subprojects/kris-core/kris-core.gradle.kts
+++ b/subprojects/kris-core/kris-core.gradle.kts
@@ -14,7 +14,6 @@ dependencies {
     implementation(libs.coroutines.rx2)
 
     testImplementation(libs.bundles.testDeps)
-    testRuntimeOnly(libs.bundles.testEngines)
 }
 
 kotlin {

--- a/subprojects/kris-guide/kris-guide.gradle.kts
+++ b/subprojects/kris-guide/kris-guide.gradle.kts
@@ -1,16 +1,10 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
     `java-library`
     kotlin("jvm")
 }
 
-tasks {
-    withType<KotlinCompile>().configureEach {
-        kotlinOptions {
-            jvmTarget = libs.versions.java.get()
-        }
-    }
+kotlin {
+    jvmToolchain(libs.versions.java.get().toInt())
 }
 
 dependencies {

--- a/subprojects/kris-guide/kris-guide.gradle.kts
+++ b/subprojects/kris-guide/kris-guide.gradle.kts
@@ -13,5 +13,4 @@ dependencies {
     implementation(libs.bundles.kotlin)
 
     testImplementation(libs.bundles.testDeps)
-    testRuntimeOnly(libs.bundles.testEngines)
 }

--- a/subprojects/kris-io/kris-io.gradle.kts
+++ b/subprojects/kris-io/kris-io.gradle.kts
@@ -10,6 +10,7 @@ plugins {
 
 kotlin {
     explicitApi()
+    jvmToolchain(libs.versions.java.get().toInt())
 }
 
 testSets {


### PR DESCRIPTION
- propertly set the jvm toolchain to java 11
- switch from testSet plugin to gradle-test-suite plugin
- Do not set the freeCompilerArgs
- disable the sonar plugin. It fails with gradle 8.0 - we'll have to wait for an update most probably.
