### PR TITLE
fix: [#138] Properly handle ris lines w/ or w/o new lines

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -56,11 +56,13 @@ The format is based on https://keepachangelog.com/en/1.0.0/[Keep a Changelog].
 
 .Removed
 
+////
+
 .Fixed
+- {url-issues}138[#138] Properly handle newlines when importing
 
 .Security
 
-////
 
 
 [[v0.4.2]]
@@ -69,7 +71,6 @@ The format is based on https://keepachangelog.com/en/1.0.0/[Keep a Changelog].
 {url-cl}0.4.1++...++0.4.2[Full Changelog]
 
 .Changed
-- {url-issues}129[#129] Allow importing M1 as String
 - Bumped dependencies kotlin,
   kotest, kluent, detekt, mockk, junit5, assertj-core, reckon,
   gradle wrapper, sonarqube gradle plugin, versions gradle plugin, nexus publish gradle plugin
@@ -78,6 +79,8 @@ The format is based on https://keepachangelog.com/en/1.0.0/[Keep a Changelog].
 .Deprecated
 - {url-issues}129[#129] RisRecord.number, RisRecord.typeOfWork (in favor of RisRecord.miscellaneous1 and RisRecord.miscellaneous3)
 
+.Fixed
+- {url-issues}129[#129] Allow importing M1 as String
 
 
 [[v0.4.1]]

--- a/subprojects/kris-core/src/main/kotlin/ch/difty/kris/implementation/RisImport.kt
+++ b/subprojects/kris-core/src/main/kotlin/ch/difty/kris/implementation/RisImport.kt
@@ -25,7 +25,8 @@ internal object RisImport {
 
         lineFlow.filterNotNull()
             .filterNot { line -> line.isEmpty() }
-            .collect { line ->
+            .collect { l ->
+                val line = l.removeSuffix("\r\n").removeSuffix("\n").removeSuffix("\r")
                 if (line.isEndOfRecord()) {
                     emit(record)
                     record = RisRecord()
@@ -42,7 +43,7 @@ internal object RisImport {
      * Returns the tag as context for parsing the next line.
      */
     private fun RisRecord.fillFrom(line: String, previousTag: RisTag?): RisTag? {
-        if (line.length <= START_INDEX_VALUE + 1)
+        if (line.length < START_INDEX_VALUE + 1)
             return previousTag
 
         val tagName = line.substring(0, TAG_LENGTH)

--- a/subprojects/kris-core/src/test/kotlin/ch/difty/kris/KRisExtensionsSpec.kt
+++ b/subprojects/kris-core/src/test/kotlin/ch/difty/kris/KRisExtensionsSpec.kt
@@ -2,7 +2,6 @@ package ch.difty.kris
 
 import io.kotest.core.spec.style.DescribeSpec
 import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldBeNull
 
 object KRisExtensionsSpec : DescribeSpec({
 
@@ -30,7 +29,7 @@ object KRisExtensionsSpec : DescribeSpec({
 
     describe("with a list of lines - each w/o new lines") {
         it("should extract startPage") {
-            recordWithoutNewLines.toRisRecords().first().startPage.shouldBeNull() // TODO wrong, should be 'shouldBeEqualTo "2"'
+            recordWithoutNewLines.toRisRecords().first().startPage shouldBeEqualTo "2"
         }
         it("should extract endPage") {
             recordWithoutNewLines.toRisRecords().first().endPage shouldBeEqualTo "28"

--- a/subprojects/kris-core/src/test/kotlin/ch/difty/kris/KRisExtensionsSpec.kt
+++ b/subprojects/kris-core/src/test/kotlin/ch/difty/kris/KRisExtensionsSpec.kt
@@ -1,0 +1,39 @@
+package ch.difty.kris
+
+import io.kotest.core.spec.style.DescribeSpec
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+
+object KRisExtensionsSpec : DescribeSpec({
+
+    val recordWithNewLines = listOf(
+        "TY  - JOUR\n",
+        "SP  - 2\n",
+        "EP  - 28\n",
+        "ER  - \n"
+    )
+    val recordWithoutNewLines = listOf(
+        "TY  - JOUR",
+        "SP  - 2",
+        "EP  - 28",
+        "ER  - "
+    )
+
+    describe("with a list of lines - each w/ new lines") {
+        it("should extract startPage") {
+            recordWithNewLines.toRisRecords().first().startPage shouldBeEqualTo "2"
+        }
+        it("should extract endPage") {
+            recordWithNewLines.toRisRecords().first().endPage shouldBeEqualTo "28"
+        }
+    }
+
+    describe("with a list of lines - each w/o new lines") {
+        it("should extract startPage") {
+            recordWithoutNewLines.toRisRecords().first().startPage.shouldBeNull() // TODO wrong, should be 'shouldBeEqualTo "2"'
+        }
+        it("should extract endPage") {
+            recordWithoutNewLines.toRisRecords().first().endPage shouldBeEqualTo "28"
+        }
+    }
+})

--- a/subprojects/kris-core/src/test/kotlin/ch/difty/kris/KRisProcessingSpec.kt
+++ b/subprojects/kris-core/src/test/kotlin/ch/difty/kris/KRisProcessingSpec.kt
@@ -54,7 +54,7 @@ object KRisProcessingSpec : DescribeSpec({
 
         describe("representing two records") {
             val twoRecordLines = lines + lines
-            it("should be parsed into one single RisRecord") {
+            it("should be parsed into two individual RisRecord") {
                 runBlocking { KRis.process(twoRecordLines.asFlow()).toList() shouldHaveSize 2 }
             }
         }
@@ -77,7 +77,7 @@ object KRisProcessingSpec : DescribeSpec({
         val abstract = "abstr line 1"
         val abstract2 = "abstr line 2"
 
-        describe("with number and abstract") {
+        describe("with miscellaneous1 and abstract") {
             val lines = listOf(
                 "TY  - $type",
                 "M1  - $miscellaneous1",
@@ -98,7 +98,6 @@ object KRisProcessingSpec : DescribeSpec({
             val lines = listOf(
                 "TY  - $type",
                 "",
-                "abcdefg",
                 "AB  - $abstract",
                 "XX  - $abstract2",
                 "ER  - "


### PR DESCRIPTION
FixeXs #138 

by removing trailing new-line characters and fixing an off-by one error while processing the invidivudal line.